### PR TITLE
removing bucket acl due to ownership rules not being set

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -3,11 +3,6 @@ resource "aws_s3_bucket" "main" {
   force_destroy = false
 }
 
-resource "aws_s3_bucket_acl" "private" {
-  bucket = aws_s3_bucket.main.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_public_access_block" "main" {
   bucket = aws_s3_bucket.main.id
 


### PR DESCRIPTION
Bucket ACLs should not be created unless object ownership spans owners. Because the Account/Bucket Owner can grant IAM permissions to write and read, ACLs are not required.