### PR TITLE
Adding var for force destroy

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -15,6 +15,7 @@ params:
       required:
         - region
         - lifecycle
+        - force_destroy
       properties:
         region:
           $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/aws-region.json
@@ -38,6 +39,11 @@ params:
               default: 60
               minimum: 1
               maximum: 365
+        force_destroy:
+          title: Force Destroy Objects
+          description: "**WARNING**: Enabling this will delete all objects in the bucket during decommission. Disabling will block bucket deletion unless bucket is empty."
+          type: boolean
+          default: false
 
 connections:
   required:
@@ -60,6 +66,7 @@ ui:
     ui:order:
       - "region"
       - "lifecycle"
+      - "force_destroy"
     region:
       ui:field: supportedCloudLocationsDropdown
       cloudService: aws

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "main" {
   bucket        = var.md_metadata.name_prefix
-  force_destroy = false
+  force_destroy = lookup(var.bucket, "force_destroy", false)
 }
 
 resource "aws_s3_bucket_ownership_controls" "main" {


### PR DESCRIPTION
Tested this change by deploying s3, uploading file to bucket, then tried to decommission from MD. Encountered expected error. I then enabled `force_destroy`, redeployed, then decommissioned again successfully.